### PR TITLE
Extended code, bug-fixes and adjusted default values in `setShunt()`

### DIFF
--- a/Adafruit_INA228.cpp
+++ b/Adafruit_INA228.cpp
@@ -302,6 +302,29 @@ void Adafruit_INA228::setVoltageConversionTime(INA228_ConversionTime time) {
       Adafruit_I2CRegisterBits(ADC_Config, 3, 9);
   voltage_conversion_time.write(time);
 }
+/**************************************************************************/
+/*!
+    @brief Reads the temperature conversion time
+    @return The temperature conversion time
+*/
+/**************************************************************************/
+INA228_ConversionTime Adafruit_INA228::getTemperatureConversionTime(void) {
+  Adafruit_I2CRegisterBits temperature_conversion_time =
+      Adafruit_I2CRegisterBits(ADC_Config, 3, 3);
+  return (INA228_ConversionTime)temperature_conversion_time.read();
+}
+/**************************************************************************/
+/*!
+    @brief Sets the temperature conversion time
+    @param time
+           The new temperature conversion time
+*/
+/**************************************************************************/
+void Adafruit_INA228::setTemperatureConversionTime(INA228_ConversionTime time) {
+  Adafruit_I2CRegisterBits temperature_conversion_time =
+      Adafruit_I2CRegisterBits(ADC_Config, 3, 3);
+  temperature_conversion_time.write(time);
+}
 
 /**************************************************************************/
 /*!

--- a/Adafruit_INA228.cpp
+++ b/Adafruit_INA228.cpp
@@ -47,6 +47,9 @@ Adafruit_INA228::Adafruit_INA228(void) {}
  *            The I2C address to be used.
  *    @param  theWire
  *            The Wire object to be used for I2C connections.
+ *    @param  skipReset
+ *            When set to true, will omit resetting all INA228 registers to
+ *            their default values. Default: false.
  *    @return True if initialization was successful, otherwise false.
  */
 bool Adafruit_INA228::begin(uint8_t i2c_address, TwoWire *theWire,

--- a/Adafruit_INA228.cpp
+++ b/Adafruit_INA228.cpp
@@ -96,6 +96,17 @@ void Adafruit_INA228::reset(void) {
   setMode(INA228_MODE_CONTINUOUS);
   getADCRange();
 }
+/**************************************************************************/
+/*!
+    @brief Resets the energy and charge accumulators of the INA228 chip
+    to 0.
+*/
+/**************************************************************************/
+void Adafruit_INA228::reset_accumulators(void) {
+  Adafruit_I2CRegisterBits reset_accumulators =
+      Adafruit_I2CRegisterBits(Config, 1, 14);
+  reset_accumulators.write(1);
+}
 
 /**************************************************************************/
 /*!

--- a/Adafruit_INA228.cpp
+++ b/Adafruit_INA228.cpp
@@ -97,7 +97,6 @@ void Adafruit_INA228::reset(void) {
       Adafruit_I2CRegisterBits(Diag_Alert, 1, 14);
   alert_conv.write(1);
   setMode(INA228_MODE_CONTINUOUS);
-  getADCRange();
 }
 /**************************************************************************/
 /*!

--- a/Adafruit_INA228.cpp
+++ b/Adafruit_INA228.cpp
@@ -49,7 +49,8 @@ Adafruit_INA228::Adafruit_INA228(void) {}
  *            The Wire object to be used for I2C connections.
  *    @return True if initialization was successful, otherwise false.
  */
-bool Adafruit_INA228::begin(uint8_t i2c_address, TwoWire *theWire, bool skipReset) {
+bool Adafruit_INA228::begin(uint8_t i2c_address, TwoWire *theWire,
+                            bool skipReset) {
   i2c_dev = new Adafruit_I2CDevice(i2c_address, theWire);
 
   if (!i2c_dev->begin()) {

--- a/Adafruit_INA228.cpp
+++ b/Adafruit_INA228.cpp
@@ -105,7 +105,7 @@ void Adafruit_INA228::reset(void) {
     to 0.
 */
 /**************************************************************************/
-void Adafruit_INA228::reset_accumulators(void) {
+void Adafruit_INA228::resetAccumulators(void) {
   Adafruit_I2CRegisterBits reset_accumulators =
       Adafruit_I2CRegisterBits(Config, 1, 14);
   reset_accumulators.write(1);

--- a/Adafruit_INA228.cpp
+++ b/Adafruit_INA228.cpp
@@ -239,7 +239,7 @@ float Adafruit_INA228::readEnergy(void) {
 */
 /**************************************************************************/
 INA228_MeasurementMode Adafruit_INA228::getMode(void) {
-  Adafruit_I2CRegisterBits mode = Adafruit_I2CRegisterBits(Config, 3, 0);
+  Adafruit_I2CRegisterBits mode = Adafruit_I2CRegisterBits(ADC_Config, 4, 12);
   return (INA228_MeasurementMode)mode.read();
 }
 /**************************************************************************/

--- a/Adafruit_INA228.h
+++ b/Adafruit_INA228.h
@@ -158,7 +158,7 @@ public:
              TwoWire *theWire = &Wire, bool skipReset = false);
   void reset(void);
 
-  void setShunt(float shunt_res = 0.1, float max_current = 3.2,
+  void setShunt(float shunt_res = 0.015, float max_current = 10.,
                 uint8_t adc_range = 0);
   uint8_t getADCRange(void);
   float readDieTemp(void);

--- a/Adafruit_INA228.h
+++ b/Adafruit_INA228.h
@@ -24,25 +24,25 @@
 
 #define INA228_I2CADDR_DEFAULT 0x40 ///< INA228 default i2c address
 #define INA228_REG_CONFIG 0x00      ///< Configuration register
-#define INA228_REG_ADCCFG 0x01
-#define INA228_REG_SHUNTCAL 0x02
-#define INA228_REG_SHUNTTEMPCO 0x03
-#define INA228_REG_VSHUNT 0x04
-#define INA228_REG_VBUS 0x05
-#define INA228_REG_DIETEMP 0x06
-#define INA228_REG_CURRENT 0x07
-#define INA228_REG_POWER 0x08
-#define INA228_REG_ENERGY 0x09
-#define INA228_REG_CHARGE 0x0A
-#define INA228_REG_DIAGALRT 0x0B
-#define INA228_REG_SOVL 0x0C
-#define INA228_REG_SUVL 0x0D
-#define INA228_REG_BOVL 0x0E
-#define INA228_REG_BUVL 0x0F
-#define INA228_REG_TEMPLIMIT 0x10
-#define INA228_REG_PWRLIMIT 0x10
-#define INA228_REG_MFG_UID 0x3E ///< Manufacturer ID Register
-#define INA228_REG_DVC_UID 0x3F ///< Device ID and Revision Register
+#define INA228_REG_ADCCFG 0x01      ///< ADC configuration register
+#define INA228_REG_SHUNTCAL 0x02    ///< Shunt calibration register
+#define INA228_REG_SHUNTTEMPCO 0x03 ///< Shunt temperature coefficient register
+#define INA228_REG_VSHUNT 0x04      ///< Shunt voltage measurement register
+#define INA228_REG_VBUS 0x05        ///< Bus voltage measurement register
+#define INA228_REG_DIETEMP 0x06     ///< Temperature measurement register
+#define INA228_REG_CURRENT 0x07     ///< Current result register
+#define INA228_REG_POWER 0x08       ///< Power result register
+#define INA228_REG_ENERGY 0x09      ///< Energy result register
+#define INA228_REG_CHARGE 0x0A      ///< Charge result register
+#define INA228_REG_DIAGALRT 0x0B    ///< Diagnostic flags and alert register
+#define INA228_REG_SOVL 0x0C        ///< Shunt overvoltage threshold register
+#define INA228_REG_SUVL 0x0D        ///< Shunt undervoltage threshold register
+#define INA228_REG_BOVL 0x0E        ///< Bus overvoltage threshold register
+#define INA228_REG_BUVL 0x0F        ///< Bus undervoltage threshold register
+#define INA228_REG_TEMPLIMIT 0x10 ///< Temperature over-limit threshold register
+#define INA228_REG_PWRLIMIT 0x10  ///< Power over-limit threshold register
+#define INA228_REG_MFG_UID 0x3E   ///< Manufacturer ID register
+#define INA228_REG_DVC_UID 0x3F   ///< Device ID and revision register
 
 /**
  * @brief Mode options.
@@ -176,14 +176,14 @@ public:
   bool conversionReady(void);
   uint16_t alertFunctionFlags(void);
 
-  float getAlertLimit(void);
-  void setAlertLimit(float limit);
+  // float getAlertLimit(void);
+  // void setAlertLimit(float limit);
   INA228_AlertLatch getAlertLatch(void);
   void setAlertLatch(INA228_AlertLatch state);
   INA228_AlertPolarity getAlertPolarity(void);
   void setAlertPolarity(INA228_AlertPolarity polarity);
-  INA228_AlertType getAlertType(void);
-  void setAlertType(INA228_AlertType alert);
+  // INA228_AlertType getAlertType(void);
+  // void setAlertType(INA228_AlertType alert);
 
   INA228_ConversionTime getCurrentConversionTime(void);
   void setCurrentConversionTime(INA228_ConversionTime time);

--- a/Adafruit_INA228.h
+++ b/Adafruit_INA228.h
@@ -175,7 +175,7 @@ public:
   void reset(void);
   void resetAccumulators(void);
 
-  void setShunt(float shunt_res = 0.015, float max_current = 10.,
+  void setShunt(float shunt_res = 0.1, float max_current = 3.2,
                 uint8_t adc_range = 0);
   uint8_t getADCRange(void);
   float readDieTemp(void);

--- a/Adafruit_INA228.h
+++ b/Adafruit_INA228.h
@@ -175,8 +175,9 @@ public:
   void reset(void);
   void resetAccumulators(void);
 
-  void setShunt(float shunt_res = 0.1, float max_current = 3.2,
-                uint8_t adc_range = 0);
+  void _updateShuntCalRegister(void);
+  void setShunt(float shunt_res = 0.1, float max_current = 3.2);
+  void setADCRange(uint8_t);
   uint8_t getADCRange(void);
   float readDieTemp(void);
 
@@ -216,8 +217,8 @@ public:
       *AlertLimit;              ///< BusIO Register for AlertLimit
 
 private:
+  float _shunt_res;
   float _current_lsb;
-  uint8_t _adc_range;
   Adafruit_I2CDevice *i2c_dev;
 };
 

--- a/Adafruit_INA228.h
+++ b/Adafruit_INA228.h
@@ -52,27 +52,27 @@
 typedef enum _mode {
   /**< SHUTDOWN: Minimize quiescient current and turn off current into the
   device inputs. Set another mode to exit shutown mode **/
-  INA228_MODE_SHUTDOWN            = 0x00,
-  INA228_MODE_TRIG_BUS            = 0x01,
-  INA228_MODE_TRIG_SHUNT          = 0x02,
-  INA228_MODE_TRIG_BUS_SHUNT      = 0x03,
-  INA228_MODE_TRIG_TEMP           = 0x04,
-  INA228_MODE_TRIG_TEMP_BUS       = 0x05,
-  INA228_MODE_TRIG_TEMP_SHUNT     = 0x06,
+  INA228_MODE_SHUTDOWN = 0x00,
+  INA228_MODE_TRIG_BUS = 0x01,
+  INA228_MODE_TRIG_SHUNT = 0x02,
+  INA228_MODE_TRIG_BUS_SHUNT = 0x03,
+  INA228_MODE_TRIG_TEMP = 0x04,
+  INA228_MODE_TRIG_TEMP_BUS = 0x05,
+  INA228_MODE_TRIG_TEMP_SHUNT = 0x06,
   INA228_MODE_TRIG_TEMP_BUS_SHUNT = 0x07,
 
-  INA228_MODE_SHUTDOWN2           = 0x08,
-  INA228_MODE_CONT_BUS            = 0x09,
-  INA228_MODE_CONT_SHUNT          = 0x0A,
-  INA228_MODE_CONT_BUS_SHUNT      = 0x0B,
-  INA228_MODE_CONT_TEMP           = 0x0C,
-  INA228_MODE_CONT_TEMP_BUS       = 0x0D,
-  INA228_MODE_CONT_TEMP_SHUNT     = 0x0E,
+  INA228_MODE_SHUTDOWN2 = 0x08,
+  INA228_MODE_CONT_BUS = 0x09,
+  INA228_MODE_CONT_SHUNT = 0x0A,
+  INA228_MODE_CONT_BUS_SHUNT = 0x0B,
+  INA228_MODE_CONT_TEMP = 0x0C,
+  INA228_MODE_CONT_TEMP_BUS = 0x0D,
+  INA228_MODE_CONT_TEMP_SHUNT = 0x0E,
   INA228_MODE_CONT_TEMP_BUS_SHUNT = 0x0F,
 
   /**< TRIGGERED: Trigger a one-shot measurement of temp, current and bus
   voltage. Set the TRIGGERED mode again to take a new measurement **/
-  INA228_MODE_TRIGGERED  = INA228_MODE_TRIG_TEMP_BUS_SHUNT,
+  INA228_MODE_TRIGGERED = INA228_MODE_TRIG_TEMP_BUS_SHUNT,
   /**< CONTINUOUS: (Default) Continuously update the temp, current, bus
   voltage and power registers with new measurements **/
   INA228_MODE_CONTINUOUS = INA228_MODE_CONT_TEMP_BUS_SHUNT

--- a/Adafruit_INA228.h
+++ b/Adafruit_INA228.h
@@ -158,7 +158,9 @@ public:
              TwoWire *theWire = &Wire, bool skipReset = false);
   void reset(void);
 
-  void setShunt(float shunt_res = 0.1, float max_current = 3.2);
+  void setShunt(float shunt_res = 0.1, float max_current = 3.2,
+                uint8_t adc_range = 0);
+  uint8_t getADCRange(void);
   float readDieTemp(void);
 
   float readCurrent(void);
@@ -198,6 +200,7 @@ public:
 
 private:
   float _current_lsb;
+  uint8_t _adc_range;
   Adafruit_I2CDevice *i2c_dev;
 };
 

--- a/Adafruit_INA228.h
+++ b/Adafruit_INA228.h
@@ -173,7 +173,7 @@ public:
   bool begin(uint8_t i2c_addr = INA228_I2CADDR_DEFAULT,
              TwoWire *theWire = &Wire, bool skipReset = false);
   void reset(void);
-  void reset_accumulators(void);
+  void resetAccumulators(void);
 
   void setShunt(float shunt_res = 0.015, float max_current = 10.,
                 uint8_t adc_range = 0);

--- a/Adafruit_INA228.h
+++ b/Adafruit_INA228.h
@@ -53,21 +53,37 @@ typedef enum _mode {
   /**< SHUTDOWN: Minimize quiescient current and turn off current into the
   device inputs. Set another mode to exit shutown mode **/
   INA228_MODE_SHUTDOWN = 0x00,
+
+  /**< Triggered bus voltage, single shot **/
   INA228_MODE_TRIG_BUS = 0x01,
+  /**< Triggered shunt voltage, single shot **/
   INA228_MODE_TRIG_SHUNT = 0x02,
+  /**< Triggered shunt voltage and bus voltage, single shot **/
   INA228_MODE_TRIG_BUS_SHUNT = 0x03,
+  /**< Triggered temperature, single shot **/
   INA228_MODE_TRIG_TEMP = 0x04,
+  /**< Triggered temperature and bus voltage, single shot **/
   INA228_MODE_TRIG_TEMP_BUS = 0x05,
+  /**< Triggered temperature and shunt voltage, single shot **/
   INA228_MODE_TRIG_TEMP_SHUNT = 0x06,
+  /**< Triggered bus voltage, shunt voltage and temperature, single shot **/
   INA228_MODE_TRIG_TEMP_BUS_SHUNT = 0x07,
 
+  /**< Shutdown **/
   INA228_MODE_SHUTDOWN2 = 0x08,
+  /**< Continuous bus voltage only **/
   INA228_MODE_CONT_BUS = 0x09,
+  /**< Continuous shunt voltage only **/
   INA228_MODE_CONT_SHUNT = 0x0A,
+  /**< Continuous shunt and bus voltage **/
   INA228_MODE_CONT_BUS_SHUNT = 0x0B,
+  /**< Continuous temperature only **/
   INA228_MODE_CONT_TEMP = 0x0C,
+  /**< Continuous bus voltage and temperature **/
   INA228_MODE_CONT_TEMP_BUS = 0x0D,
+  /**< Continuous temperature and shunt voltage **/
   INA228_MODE_CONT_TEMP_SHUNT = 0x0E,
+  /**< Continuous bus voltage, shunt voltage and temperature **/
   INA228_MODE_CONT_TEMP_BUS_SHUNT = 0x0F,
 
   /**< TRIGGERED: Trigger a one-shot measurement of temp, current and bus

--- a/Adafruit_INA228.h
+++ b/Adafruit_INA228.h
@@ -175,7 +175,6 @@ public:
   void reset(void);
   void resetAccumulators(void);
 
-  void _updateShuntCalRegister(void);
   void setShunt(float shunt_res = 0.1, float max_current = 3.2);
   void setADCRange(uint8_t);
   uint8_t getADCRange(void);
@@ -217,6 +216,7 @@ public:
       *AlertLimit;              ///< BusIO Register for AlertLimit
 
 private:
+  void _updateShuntCalRegister(void);
   float _shunt_res;
   float _current_lsb;
   Adafruit_I2CDevice *i2c_dev;

--- a/Adafruit_INA228.h
+++ b/Adafruit_INA228.h
@@ -50,16 +50,32 @@
  * Allowed values for setMode.
  */
 typedef enum _mode {
-  INA228_MODE_SHUTDOWN = 0x00, /**< SHUTDOWN: Minimize quiescient current and
-                                turn off current into the device inputs. Set
-                                another mode to exit shutown mode **/
-  INA228_MODE_TRIGGERED =
-      0x07,                      /**< TRIGGERED: Trigger a one-shot measurement
-                                   of temp, current and bus voltage. Set the TRIGGERED
-                                   mode again to take a new measurement **/
-  INA228_MODE_CONTINUOUS = 0x0F, /**< CONTINUOUS: (Default) Continuously update
-                                    the temp, current, bus voltage and power
-                                    registers with new measurements **/
+  /**< SHUTDOWN: Minimize quiescient current and turn off current into the
+  device inputs. Set another mode to exit shutown mode **/
+  INA228_MODE_SHUTDOWN            = 0x00,
+  INA228_MODE_TRIG_BUS            = 0x01,
+  INA228_MODE_TRIG_SHUNT          = 0x02,
+  INA228_MODE_TRIG_BUS_SHUNT      = 0x03,
+  INA228_MODE_TRIG_TEMP           = 0x04,
+  INA228_MODE_TRIG_TEMP_BUS       = 0x05,
+  INA228_MODE_TRIG_TEMP_SHUNT     = 0x06,
+  INA228_MODE_TRIG_TEMP_BUS_SHUNT = 0x07,
+
+  INA228_MODE_SHUTDOWN2           = 0x08,
+  INA228_MODE_CONT_BUS            = 0x09,
+  INA228_MODE_CONT_SHUNT          = 0x0A,
+  INA228_MODE_CONT_BUS_SHUNT      = 0x0B,
+  INA228_MODE_CONT_TEMP           = 0x0C,
+  INA228_MODE_CONT_TEMP_BUS       = 0x0D,
+  INA228_MODE_CONT_TEMP_SHUNT     = 0x0E,
+  INA228_MODE_CONT_TEMP_BUS_SHUNT = 0x0F,
+
+  /**< TRIGGERED: Trigger a one-shot measurement of temp, current and bus
+  voltage. Set the TRIGGERED mode again to take a new measurement **/
+  INA228_MODE_TRIGGERED  = INA228_MODE_TRIG_TEMP_BUS_SHUNT,
+  /**< CONTINUOUS: (Default) Continuously update the temp, current, bus
+  voltage and power registers with new measurements **/
+  INA228_MODE_CONTINUOUS = INA228_MODE_CONT_TEMP_BUS_SHUNT
 } INA228_MeasurementMode;
 
 /**

--- a/Adafruit_INA228.h
+++ b/Adafruit_INA228.h
@@ -186,6 +186,8 @@ public:
   void setCurrentConversionTime(INA228_ConversionTime time);
   INA228_ConversionTime getVoltageConversionTime(void);
   void setVoltageConversionTime(INA228_ConversionTime time);
+  INA228_ConversionTime getTemperatureConversionTime(void);
+  void setTemperatureConversionTime(INA228_ConversionTime time);
   INA228_AveragingCount getAveragingCount(void);
   void setAveragingCount(INA228_AveragingCount count);
 

--- a/Adafruit_INA228.h
+++ b/Adafruit_INA228.h
@@ -157,6 +157,7 @@ public:
   bool begin(uint8_t i2c_addr = INA228_I2CADDR_DEFAULT,
              TwoWire *theWire = &Wire, bool skipReset = false);
   void reset(void);
+  void reset_accumulators(void);
 
   void setShunt(float shunt_res = 0.015, float max_current = 10.,
                 uint8_t adc_range = 0);


### PR DESCRIPTION
Code extended, see list below. The only code break is that the default values in method `setShunt()` now follow the spec sheet, i.e. shunt_res = 0.015 and max_current = 10. That is the last commit in this list, which I could remove from the PR if needed. The rest of the requested commits are not breaking. Tested.

* Added missing modes in enum `INA228_MeasurementMode`
* Added methods `set/getTemperatureConversionTime()`
* Added optional `adc_range` parameter in method `setShunt()`
* Added method `getADCRange()`
* Default parameter values in `setShunt()` follow spec sheet now

Keep up the good work :)

Followed up:
* Fixed wrong bits retrieved by `getMode()`
* Added method `reset_accumulators()`
* Fixed doxygen report by adding missing docstrings