### PR TITLE
add bus voltage over limit

### DIFF
--- a/Adafruit_INA228.cpp
+++ b/Adafruit_INA228.cpp
@@ -470,3 +470,30 @@ uint16_t Adafruit_INA228::alertFunctionFlags(void) {
       Adafruit_I2CRegisterBits(Diag_Alert, 12, 0);
   return alert_flags.read();
 }
+/**************************************************************************/
+/*!
+    @brief Sets Bus Voltage Over Limit
+    @param limit
+           The limit for triggering the alert in mV
+*/
+/**************************************************************************/
+void Adafruit_INA228::setBusVoltageOverLimit(float limit) {
+  Adafruit_I2CRegister bovl =
+      Adafruit_I2CRegister(i2c_dev, INA228_REG_BOVL, 2, MSBFIRST);
+
+  uint16_t value = ((uint16_t) limit / 3.125);
+  bovl.write(value);
+}
+/**************************************************************************/
+/*!
+    @brief Reads the bus voltage over limit
+    @return limit in mV
+*/
+/**************************************************************************/
+float Adafruit_INA228::getBusVoltageOverLimit(void) {
+  Adafruit_I2CRegister bovl =
+      Adafruit_I2CRegister(i2c_dev, INA228_REG_BOVL, 2, MSBFIRST);
+
+  float limit_mv = (float)((uint32_t)bovl.read()) * 3.125;
+  return limit_mv;
+}

--- a/Adafruit_INA228.cpp
+++ b/Adafruit_INA228.cpp
@@ -481,7 +481,7 @@ void Adafruit_INA228::setBusVoltageOverLimit(float limit) {
   Adafruit_I2CRegister bovl =
       Adafruit_I2CRegister(i2c_dev, INA228_REG_BOVL, 2, MSBFIRST);
 
-  uint16_t value = ((uint16_t) limit / 3.125);
+  uint16_t value = ((uint16_t)limit / 3.125);
   bovl.write(value);
 }
 /**************************************************************************/

--- a/Adafruit_INA228.h
+++ b/Adafruit_INA228.h
@@ -208,6 +208,9 @@ public:
   // INA228_AlertType getAlertType(void);
   // void setAlertType(INA228_AlertType alert);
 
+  float getBusVoltageOverLimit(void);
+  void setBusVoltageOverLimit(float);
+
   INA228_ConversionTime getCurrentConversionTime(void);
   void setCurrentConversionTime(INA228_ConversionTime time);
   INA228_ConversionTime getVoltageConversionTime(void);


### PR DESCRIPTION
- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

Add `getBusVoltageOverLimit` and `setBusVoltageOverLimit` functions to read & write the BOVL register.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

Only implemented for the BOVL register for now.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

This doesn't affect existing tests/examples.
Example code:

```
  ina228.setBusVoltageOverLimit(3000.0);

  float limit = ina228.getBusVoltageOverLimit();
  Serial.print("Bus over voltage limit: ");
  Serial.print(limit);
  Serial.println(" mV.");

  uint16_t flags = ina228.alertFunctionFlags();
  if (flags & 16) {
    triggered = true;
    Serial.print("Triggered at ");
    Serial.print(limit);
    Serial.println(" mV.");
  }
```

