### PR TITLE
Add readCharge() function for INA228

### DIFF
--- a/Adafruit_INA228.cpp
+++ b/Adafruit_INA228.cpp
@@ -114,6 +114,32 @@ float Adafruit_INA228::readEnergy(void) {
 
 /**************************************************************************/
 /*!
+    @brief Reads and scales the current value of the Charge register.
+    @return The current Charge calculation in Coulombs
+*/
+/**************************************************************************/
+float Adafruit_INA228::readCharge(void) {
+  Adafruit_I2CRegister charge =
+      Adafruit_I2CRegister(i2c_dev, INA228_REG_CHARGE, 5, MSBFIRST);
+  uint8_t buff[5];
+  charge.read(buff, 5);
+  
+  // Convert 40-bit two's complement value
+  int64_t c = 0;
+  for (int i = 0; i < 5; i++) {
+    c = (c << 8) | buff[i];
+  }
+  
+  // Handle sign extension for 40-bit two's complement
+  if (c & ((int64_t)1 << 39)) {
+    c |= 0xFFFFFF0000000000; // Sign extend to 64 bits
+  }
+  
+  return (float)c * _current_lsb;
+}
+
+/**************************************************************************/
+/*!
     @brief Returns the current alert type
     @return The current alert type
 */

--- a/Adafruit_INA228.cpp
+++ b/Adafruit_INA228.cpp
@@ -123,18 +123,18 @@ float Adafruit_INA228::readCharge(void) {
       Adafruit_I2CRegister(i2c_dev, INA228_REG_CHARGE, 5, MSBFIRST);
   uint8_t buff[5];
   charge.read(buff, 5);
-  
+
   // Convert 40-bit two's complement value
   int64_t c = 0;
   for (int i = 0; i < 5; i++) {
     c = (c << 8) | buff[i];
   }
-  
+
   // Handle sign extension for 40-bit two's complement
   if (c & ((int64_t)1 << 39)) {
     c |= 0xFFFFFF0000000000; // Sign extend to 64 bits
   }
-  
+
   return (float)c * _current_lsb;
 }
 

--- a/Adafruit_INA228.h
+++ b/Adafruit_INA228.h
@@ -149,7 +149,7 @@ class Adafruit_INA228 : public Adafruit_INA2xx {
 
   // INA228 specific functions
   float readEnergy(void);
-  float readCharge(void); 
+  float readCharge(void);
   INA228_AlertType getAlertType(void);
   void setAlertType(INA228_AlertType alert);
   void resetAccumulators(void);

--- a/Adafruit_INA228.h
+++ b/Adafruit_INA228.h
@@ -24,7 +24,7 @@
 
 // INA228 specific registers
 #define INA228_REG_ENERGY 0x09      ///< Energy result register
-#define INA228_REG_CHARGE 0x0A      ///< Charge result register
+#define INA228_REG_CHARGE 0x0A      ///< Charge result register (40-bit)
 #define INA228_REG_SHUNTTEMPCO 0x03 ///< Shunt temperature coefficient register
 
 ///@{
@@ -149,6 +149,7 @@ class Adafruit_INA228 : public Adafruit_INA2xx {
 
   // INA228 specific functions
   float readEnergy(void);
+  float readCharge(void); 
   INA228_AlertType getAlertType(void);
   void setAlertType(INA228_AlertType alert);
   void resetAccumulators(void);


### PR DESCRIPTION
- Add new method to read the 40-bit CHARGE register
- Convert the register value to Coulombs using CURRENT_LSB
- Properly handle sign extension for 40-bit two's complement values